### PR TITLE
Attach Chroma client to YOLOv5

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -145,7 +145,7 @@ def run(
         metadata = ["test_metadata"] * len(pred[0])
         inferences = ["test_inference"] * len(pred[0])
 
-        chroma.log_batch(embedding_data=embeddings[0].float().tolist(),input_uri=paths,category_name=class_names,dataset="yolo_test", metadata=metadata, inference_data=inferences)
+        chroma.log(embedding_data=embeddings[0].float().tolist(),input_uri=paths,category_name=class_names,dataset="yolo_test")
 
         # Process predictions
         for i, det in enumerate(pred):  # per image

--- a/models/yolo.py
+++ b/models/yolo.py
@@ -55,6 +55,7 @@ class Detect(nn.Module):
 
     def forward(self, x):
         z = []  # inference output
+        embeddings = [] # embeddings output 
         for i in range(self.nl):
             x[i] = self.m[i](x[i])  # conv
             bs, _, ny, nx = x[i].shape  # x(bs,255,20,20) to x(bs,3,20,20,85)
@@ -75,8 +76,9 @@ class Detect(nn.Module):
                     wh = (wh * 2) ** 2 * self.anchor_grid[i]  # wh
                     y = torch.cat((xy, wh, conf), 4)
                 z.append(y.view(bs, self.na * nx * ny, self.no))
+                embeddings.append(x[i].view(bs, self.na * nx * ny, self.no))
 
-        return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x)
+        return x if self.training else (torch.cat(z, 1),) if self.export else (torch.cat(z, 1), x, torch.cat(embeddings, 1))
 
     def _make_grid(self, nx=20, ny=20, i=0, torch_1_10=check_version(torch.__version__, '1.10.0')):
         d = self.anchors[i].device


### PR DESCRIPTION
This is an example of how to attach Chroma to YOLOv5.

The client itself was relatively painless. Experience with YOLOv3 let us retrofit this one more easily - the code is also cleaner than YOLOv3.

This is more lines of code than I'd like the user to have to write. This is mainly a consequence of non-max suppression being a relatively complex operation. For the beta phase, I think this is still fine.

# To Test

- Create a new virtualenv / conda env for YOLOv5
- Install YOLOv5 requirements from the `chroma-yolov5` repo: `pip install -r requirements.txt` 
- In the `chroma/chroma-client` directory, install the client in the same environment with `pip install -e .` 
- Run the Chroma server from the `chroma/chroma-server` directory with `uvicorn chroma_server:app --reload --log-level=debug`
- In the `chroma-yolov5` repo run `python detect.py` 

In the server output, there should be two successful POSTs representing batch writes from the two test images:

```
INFO:     127.0.0.1:62138 - "POST /api/v1/add HTTP/1.1" 201 Created
INFO:     127.0.0.1:62140 - "POST /api/v1/add HTTP/1.1" 201 Created
```
